### PR TITLE
Add Deep Dive Topic Generator prompt for article writing

### DIFF
--- a/prompts/content/article-writing/README.md
+++ b/prompts/content/article-writing/README.md
@@ -15,3 +15,4 @@ Craft better long-form content with prompts that focus on structure, clarity, an
 - [Blog Feature Image Prompt](feature-image-blog.md) - describe the hero graphic you need for AI image tools.
 - [Contextualize Research](contextualize-research.md) - transform raw notes into persuasive, easy-to-follow paragraphs.
 - [Summarize & Conclude](content-conclusion.md) - close with a tidy recap and suggested next step.
+- [Deep Dive Topic Generator](deep-dive-topics.md) - surface drill-down article ideas from existing drafts, research, or outlines.

--- a/prompts/content/article-writing/deep-dive-topics.md
+++ b/prompts/content/article-writing/deep-dive-topics.md
@@ -38,3 +38,6 @@ Context:
 ```
 
 The model will return three net-new deep dive article titles plus one tailored drill-down topic per heading so you can keep expanding the series with intent.
+
+> [!TIP]
+> Use the generated deep dive topics to plan your next articles or series. This prompt works best when your context includes clear headings or a well-structured outline. For best results, paste detailed notes or a full draft to surface the most relevant follow-up ideas.

--- a/prompts/content/article-writing/deep-dive-topics.md
+++ b/prompts/content/article-writing/deep-dive-topics.md
@@ -1,0 +1,40 @@
+---
+title: Deep Dive Topic Generator
+category: content
+subcategory: article-writing
+description: Turn existing context or outlines into drill-down article ideas for deeper follow-up pieces.
+llm_tools:
+  - ChatGPT
+  - Microsoft Copilot
+inputs:
+  - Source context (notes, article, outline, or headings)
+---
+
+# Deep Dive Topic Generator
+
+Use this prompt after publishing an article or outlining a series to uncover rich follow-up topics. It first surfaces three overall deep-dive ideas, then maps specific drill-down angles to each heading in your context.
+
+## Prompt
+
+```text
+Based on the following context, provide 3 potential deep dive, drill down content topics that would make for great articles.
+
+---
+
+For each heading, provide a potential deep dive, drill down content topic that would make for a great article.
+
+Context:
+<Paste article draft, outline headings, or research notes>
+```
+
+## Example
+
+```text
+Context:
+# Modern Customer Support Playbooks
+## Heading: Building a Proactive Support Culture
+## Heading: Leveraging AI Assistants in Support
+## Heading: Measuring Support Quality Beyond CSAT
+```
+
+The model will return three net-new deep dive article titles plus one tailored drill-down topic per heading so you can keep expanding the series with intent.


### PR DESCRIPTION
This pull request adds a new prompt to the article-writing section to help users generate deep-dive topics for follow-up articles. The main change is the introduction of the "Deep Dive Topic Generator," which surfaces drill-down article ideas based on existing drafts, research, or outlines.

**New Deep Dive Topic Generation:**

* Added a new prompt file `deep-dive-topics.md` that describes how to turn existing context or outlines into drill-down article ideas for deeper follow-up pieces, including usage instructions and examples.
* Updated the `README.md` to reference the new "Deep Dive Topic Generator" prompt, making it discoverable alongside existing prompts.