### PR TITLE
Add Career Performance Review prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,13 +10,14 @@ A library of copy-ready prompts for ChatGPT, Copilot, and similar tools. Every p
 
 All prompts live under [`prompts/`](prompts/README.md). The folder categories are intentionally opinionated to keep things organized:
 
-| Domain              | Folder                       | Highlights                                                    |
-| ------------------- | ---------------------------- | ------------------------------------------------------------- |
-| Content - Writing   | `prompts/content/`           | Outlining, SEO metadata, feature images, conclusions          |
-| Content - Reviewing | `prompts/content/reviewing/` | Language quality checks, topic accuracy, readability feedback |
-| Social Media        | `prompts/social/`            | Conversation-starting posts and image prompts                 |
-| Coding              | `prompts/coding/`            | Release-note system prompt ready for changelog inputs         |
-| Knowledge Retrieval | `prompts/knowledge/`         | Context-grounded answering for RAG setups                     |
+| Domain              | Folder                        | Highlights                                                    |
+| ------------------- | ----------------------------- | ------------------------------------------------------------- |
+| Content - Writing   | `prompts/content/`            | Outlining, SEO metadata, feature images, conclusions          |
+| Content - Reviewing | `prompts/content/reviewing/`  | Language quality checks, topic accuracy, readability feedback |
+| Social Media        | `prompts/social/`             | Conversation-starting posts and image prompts                 |
+| Coding              | `prompts/coding/`             | Release-note system prompt ready for changelog inputs         |
+| Knowledge Retrieval | `prompts/knowledge/`          | Context-grounded answering for RAG setups                     |
+| Career Development  | `prompts/career/development/` | Performance reviews, growth plans, and professional coaching  |
 
 ## How to Use
 

--- a/prompts/career/development/README.md
+++ b/prompts/career/development/README.md
@@ -1,0 +1,10 @@
+---
+title: Career Development
+description: Future prompts for mentoring, performance reviews, and professional growth plans.
+---
+
+# Career Development
+
+These prompts guide coaching conversations, resume refreshes, interview prep, or skills mapping.
+
+- [Performance Review Impact Assessment](performance-review-impact-assessment.md) - turn raw accomplishments, setbacks, and goals into a polished review submission template.

--- a/prompts/career/development/README.md
+++ b/prompts/career/development/README.md
@@ -1,6 +1,6 @@
 ---
 title: Career Development
-description: Future prompts for mentoring, performance reviews, and professional growth plans.
+description: Prompts that guide career growth through mentoring, performance reviews, and professional development planning.
 ---
 
 # Career Development

--- a/prompts/career/development/performance-review-impact-assessment.md
+++ b/prompts/career/development/performance-review-impact-assessment.md
@@ -1,0 +1,93 @@
+---
+title: Performance Review Impact Assessment
+category: career
+subcategory: development
+description: Guide a career coach style response that turns raw accomplishments, setbacks, and goals into a compelling review package.
+llm_tools:
+  - ChatGPT
+  - Microsoft Copilot
+inputs:
+  - Role and seniority level
+  - Review cadence or program name
+  - Summary of priorities and accomplishments
+  - Organization goals for the next period
+  - Desired growth areas
+---
+
+# Performance Review Impact Assessment
+
+Use this prompt to convert your annual or semi-annual notes into a polished impact assessment that resonates with busy managers and promotion committees. It keeps the structure flexible so anyone can drop in their role, accomplishments, future goals, and growth areas.
+
+## Prompt
+
+```text
+You are an expert career coach for <ROLE AND LEVEL> at <COMPANY>. You craft compelling impact assessments so managers and senior leadership can quickly grasp the employee's value and growth trajectory.
+
+You will be provided with:
+
+- A summary of the employee's core priorities
+- A detailed list of accomplishments/projects/initiatives, contributions to the success of others, and examples of leveraging others from the review period
+- A list of their business/team goals
+- A list of desired growth areas and career aspirations
+
+Create a comprehensive impact assessment with the following sections and character limits:
+
+1. **What results did you deliver, and how did you do it?**
+   - Produce a detailed, sectioned, bullet-list summary of key accomplishments, contributions to others, and leverage moments.
+   - Conclude each section with a concise **Impact** statement that quantifies outcomes whenever possible.
+   - Weave in qualitative and quantitative facts, stakeholder names, and OKR details to tell a cohesive story.
+
+2. **Reflect on recent setbacks - what did you learn and how did you grow?**
+   - Summarize challenges or setbacks, what was learned, and how those lessons will influence future work.
+
+3. **What are your goals for the upcoming period?**
+   - For each current goal, craft 3-5 SMART objectives aligned to the employee's role and aspirations.
+   - Include success measures and explain how each objective advances the broader business goals.
+
+4. **How will your actions and behaviors help you reach your goals?**
+   - Outline specific actions, behaviors, mindsets, and resources (mentorship, training, collaboration) required to achieve the goals.
+
+Guidelines:
+
+- Emphasize impact that ties individual accomplishments to team or business outcomes.
+- Highlight contributions to others' success, instances of leveraging peers, and examples of learning agility.
+- Include quantifiable metrics whenever available.
+- Maintain a professional, concise, and engaging tone that is easy for senior leaders to scan.
+- Use sections, bullets, and light formatting (bold/italics) to enhance readability.
+- Avoid jargon unfamiliar to cross-functional readers.
+- Tailor the narrative to the provided role description and aspirations.
+- **DO NOT** invent details—use only the supplied information.
+
+Context:
+<Insert priorities, accomplishments, setbacks, org goals, and aspirations>
+```
+
+## Example Usage
+
+```text
+Context:
+
+---
+
+Here is the role description for a Senior Software Engineer at TechCorp:
+
+- Lead the design and implementation of scalable software solutions.
+- Mentor junior engineers and foster a collaborative team environment.
+- Drive cross-functional projects that align with company objectives.
+
+---
+
+Here are summaries of my accomplishments over the past six months:
+
+...
+
+---
+
+Here are our business goals and objectives for the next period:
+
+...
+
+---
+```
+
+Feed the model your notes beneath the prompt and it will shape them into a reader-friendly impact assessment you can paste directly into your review system.

--- a/prompts/career/development/performance-review-impact-assessment.md
+++ b/prompts/career/development/performance-review-impact-assessment.md
@@ -30,7 +30,7 @@ You will be provided with:
 - A list of their business/team goals
 - A list of desired growth areas and career aspirations
 
-Create a comprehensive impact assessment with the following sections and character limits:
+Create a comprehensive impact assessment with the following sections:
 
 1. **What results did you deliver, and how did you do it?**
    - Produce a detailed, sectioned, bullet-list summary of key accomplishments, contributions to others, and leverage moments.


### PR DESCRIPTION
This pull request introduces a new "Career Development" domain to the prompt library, expanding its coverage to include mentoring, performance reviews, and professional growth plans. The main addition is a comprehensive prompt for guiding performance review impact assessments, designed to help users turn raw notes into polished review submissions.

**New Career Development Domain:**

* Added a new folder `prompts/career/development/` to organize prompts related to career growth, mentoring, and performance reviews.
* Created a domain README (`prompts/career/development/README.md`) describing the purpose and listing the first prompt: Performance Review Impact Assessment.

**Performance Review Impact Assessment Prompt:**

* Added `performance-review-impact-assessment.md`, a detailed prompt template for crafting impact assessments from employee notes, including instructions, context, and example usage.

These changes make the prompt library more useful for professional development scenarios and help users produce high-quality review submissions.