### PR TITLE
Add custom Outlook Copilot email drafting instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,13 +10,14 @@ A library of copy-ready prompts for ChatGPT, Copilot, and similar tools. Every p
 
 All prompts live under [`prompts/`](prompts/README.md). The folder categories are intentionally opinionated to keep things organized:
 
-| Domain              | Folder                       | Highlights                                                    |
-| ------------------- | ---------------------------- | ------------------------------------------------------------- |
-| Content - Writing   | `prompts/content/`           | Outlining, SEO metadata, feature images, conclusions          |
-| Content - Reviewing | `prompts/content/reviewing/` | Language quality checks, topic accuracy, readability feedback |
-| Social Media        | `prompts/social/`            | Conversation-starting posts and image prompts                 |
-| Coding              | `prompts/coding/`            | Release-note system prompt ready for changelog inputs         |
-| Knowledge Retrieval | `prompts/knowledge/`         | Context-grounded answering for RAG setups                     |
+| Domain                 | Folder                            | Highlights                                                    |
+| ---------------------- | --------------------------------- | ------------------------------------------------------------- |
+| Content - Writing      | `prompts/content/`                | Outlining, SEO metadata, feature images, conclusions          |
+| Content - Reviewing    | `prompts/content/reviewing/`      | Language quality checks, topic accuracy, readability feedback |
+| Social Media           | `prompts/social/`                 | Conversation-starting posts and image prompts                 |
+| Coding                 | `prompts/coding/`                 | Release-note system prompt ready for changelog inputs         |
+| Knowledge Retrieval    | `prompts/knowledge/`              | Context-grounded answering for RAG setups                     |
+| Business Communication | `prompts/business/communication/` | Outlook Copilot drafting rules and stakeholder messaging      |
 
 ## How to Use
 

--- a/prompts/business/communication/README.md
+++ b/prompts/business/communication/README.md
@@ -1,0 +1,10 @@
+---
+title: Business Communication
+description: Prompts and reusable instructions that keep stakeholder communications consistent.
+---
+
+# Business Communication
+
+Use these prompts to standardize updates, announcements, or executive comms across teams.
+
+- [Outlook Copilot Draft Instructions](outlook-copilot-draft-instructions.md) - enforce tone, structure, and clarity rules for every Copilot-generated email.

--- a/prompts/business/communication/outlook-copilot-draft-instructions.md
+++ b/prompts/business/communication/outlook-copilot-draft-instructions.md
@@ -2,7 +2,7 @@
 title: Outlook Copilot Draft Instructions
 category: business
 subcategory: communication
-description: Custom drafting rules for Outlook Copilot so every email stays clear, polite, and action oriented.
+description: Custom drafting rules for Outlook Copilot so every email stays clear, polite, and action-oriented.
 llm_tools:
   - Microsoft Outlook Copilot
 inputs:

--- a/prompts/business/communication/outlook-copilot-draft-instructions.md
+++ b/prompts/business/communication/outlook-copilot-draft-instructions.md
@@ -1,0 +1,33 @@
+---
+title: Outlook Copilot Draft Instructions
+category: business
+subcategory: communication
+description: Custom drafting rules for Outlook Copilot so every email stays clear, polite, and action oriented.
+llm_tools:
+  - Microsoft Outlook Copilot
+inputs:
+  - Recipient names or groups
+  - Key update or request details
+  - Technical facts or next steps to highlight
+---
+
+# Outlook Copilot Draft Instructions
+
+Keep Copilot-generated emails consistent by setting these instructions inside Outlook: **Settings → Copilot → Draft instructions**. Once saved, every draft Copilot produces will follow the tone, structure, and clarity rules below—no copy/paste required per message.
+
+## Draft Instruction
+
+```text
+- Use a friendly-yet-professional greeting (e.g., opening with Hi <recipient> or Hello <recipient> if more formal)
+- Address teams/groups by name when writing to multiple stakeholders
+- Lead with concise context and the key update
+- Explain any technical details clearly, stating what we know, product/tool names, and call out problems with plain language, including any next steps
+- Close with a simple sign-off (e.g., Regards or Best regards)
+- Maintain a balanced tone
+- Be polite and collaborative, never accusatory
+- Be clear and precise when explaining details, but avoid unnecessary jargon
+- Be forward-looking, emphasizing next steps
+```
+
+> [!TIP]
+> Pair these instructions with message-specific prompts (e.g., “Draft a status update about…”). Copilot will merge the situational prompt with this reusable guideline for more predictable output.

--- a/prompts/business/communication/outlook-copilot-draft-instructions.md
+++ b/prompts/business/communication/outlook-copilot-draft-instructions.md
@@ -15,7 +15,7 @@ inputs:
 
 Keep Copilot-generated emails consistent by setting these instructions inside Outlook: **Settings → Copilot → Draft instructions**. Once saved, every draft Copilot produces will follow the tone, structure, and clarity rules below—no copy/paste required per message.
 
-## Draft Instruction
+## Prompt
 
 ```text
 - Use a friendly-yet-professional greeting (e.g., opening with Hi <recipient> or Hello <recipient> if more formal)


### PR DESCRIPTION
This pull request adds a new category for business communication prompts to help standardize stakeholder messaging, especially for Outlook Copilot-generated emails. It updates documentation to reflect the new category and introduces reusable instructions for drafting consistent, clear, and polite business emails.

**Documentation updates:**

* Added the `Business Communication` category to the prompt directory table in `README.md`, highlighting Outlook Copilot drafting rules and stakeholder messaging.
* Created `prompts/business/communication/README.md` to describe the new category and link to its first prompt, "Outlook Copilot Draft Instructions."

**New business communication prompt:**

* Added `prompts/business/communication/outlook-copilot-draft-instructions.md`, providing detailed reusable instructions for Copilot-generated emails, including tone, structure, and clarity guidelines, as well as example inputs and usage tips.