### PR TITLE
Add Outlook Inbox prioritization instructions

### DIFF
--- a/prompts/business/communication/README.md
+++ b/prompts/business/communication/README.md
@@ -8,5 +8,5 @@ description: Prompts and reusable instructions that keep stakeholder communicati
 Use these prompts to standardize updates, announcements, or executive comms across teams.
 
 - [Outlook Copilot High-Priority Instructions](outlook-high-priority-instructions.md) - teach Outlook Copilot which emails deserve top placement based on senders, keywords, and urgency signals.
-- [Outlook Copilot Low-Priority Instructions](outlook-low-priority-instructions.md) - teach Outlook Copilot that can safely drop to the bottom of your inbox.
+- [Outlook Copilot Low-Priority Instructions](outlook-low-priority-instructions.md) - teach Outlook Copilot emails that can safely drop to the bottom of your inbox.
 - [Outlook Copilot Draft Instructions](outlook-copilot-draft-instructions.md) - enforce tone, structure, and clarity rules for every Copilot-generated email.

--- a/prompts/business/communication/README.md
+++ b/prompts/business/communication/README.md
@@ -1,0 +1,11 @@
+---
+title: Business Communication
+description: Prompts and reusable instructions that keep stakeholder communications consistent.
+---
+
+# Business Communication
+
+Use these prompts to standardize updates, announcements, or executive comms across teams.
+
+- [Outlook Copilot High-Priority Instructions](outlook-high-priority-instructions.md) - teach Outlook Copilot which emails deserve top placement based on senders, keywords, and urgency signals.
+- [Outlook Copilot Low-Priority Instructions](outlook-low-priority-instructions.md) - teach Outlook Copilot that can safely drop to the bottom of your inbox.

--- a/prompts/business/communication/outlook-high-priority-instructions.md
+++ b/prompts/business/communication/outlook-high-priority-instructions.md
@@ -1,0 +1,41 @@
+---
+title: Outlook Copilot Priority Instructions
+category: business
+subcategory: communication
+description: Teach Outlook Copilot which messages deserve top billing so high-priority mail is surfaced automatically.
+llm_tools:
+  - Microsoft Outlook Copilot
+inputs:
+  - Role or function
+  - Examples of high-priority senders
+  - Types of incidents, deadlines, or keywords that require fast action
+  - Signals across Teams, monitoring, or attachments that indicate urgency
+---
+
+# Outlook Copilot Priority Instructions
+
+Outlook now lets you define custom rules so Copilot highlights the messages that matter most. Adjust and drop each of the instructions below into **Settings → Copilot → Prioritize** and tailor the placeholders to reflect your role.
+
+> [!IMPORTANT]
+> Each instruction can be added as a separate row in the Prioritize settings. These will be combined into a single instruction set that Copilot uses to rank incoming emails.
+
+## High Priority Instructions
+
+```text
+- Messages from my manager (<MANAGER NAME/EMAIL>) or leadership (<LEADER NAMES/EMAILS>)
+- Messages from key stakeholders such as <PROGRAM/ACCOUNT/BUSINESS/CUSTOMER TEAMS>
+- Messages flagged as urgent/important
+- Messages or meeting invites that directly asks me for a quick RSVP or response
+- Messages with a time-sensitive deadline, e.g. action required by end of day
+- Messages related to security or compliance, such as vulnerability disclosures or urgent policy updates
+- Messages containing keywords like <LIST OF KEYWORDS>
+- Messages where I am @mentioned in a thread (i.e. directly in the To: line rather than CC:)
+- Messages that tie into my active projects or initiatives where a delay could cascade downstream
+- Draft messages requiring my review or feedback
+- Messages from teams where someone says "I sent you an email"
+```
+
+Configure these instructions once and Outlook Copilot will consistently surface the right emails at the top of your inbox.
+
+> [!TIP]
+> Consider any of your specific role responsibilities to include as high-priority signals. For example, customer success managers might want to prioritize messages from customers reporting issues, while product managers could highlight emails about upcoming launch deadlines.

--- a/prompts/business/communication/outlook-low-priority-instructions.md
+++ b/prompts/business/communication/outlook-low-priority-instructions.md
@@ -24,8 +24,7 @@ Pair this template with Outlook’s priority feature to push FYI-only or low-imp
 - Messages related to company-wide announcements (e.g., "All Hands" meetings)
 - Newsletters or marketing blasts (internal "news you can use", updates, etc.)
 - Automated digests (daily build summaries, reminders, etc.)
-- Messages where I'm CC'd or FYI-only threads
-- Messages where I'm only copied, not directly addressed
+- Messages where I'm CC'd, only copied (not directly addressed), or part of FYI-only threads
 - "Just keeping you in the loop" messages that don't require action from me
 - Recurring status updates with no new deliverables or decisions required
 - "For your reference" docs or whitepapers with no deadlines

--- a/prompts/business/communication/outlook-low-priority-instructions.md
+++ b/prompts/business/communication/outlook-low-priority-instructions.md
@@ -1,0 +1,41 @@
+---
+title: Outlook Copilot Low-Priority Instructions
+category: business
+subcategory: communication
+description: Teach Outlook Copilot which messages can be safely deprioritized so high-signal mail stays in focus.
+llm_tools:
+  - Microsoft Outlook Copilot
+inputs:
+  - Role or function
+  - Examples of mailing lists, notifications, or content that rarely need fast action
+  - Phrases that signal FYI-only or no-deadline work
+---
+
+# Outlook Copilot Low-Priority Instructions
+
+Pair this template with Outlook’s priority feature to push FYI-only or low-impact messages further down the view. Adjust and drop each of the instructions below into **Settings → Copilot → Prioritize** and tailor the placeholders to reflect your role.
+
+> [!IMPORTANT]
+> Each instruction can be added as a separate row in the Prioritize settings. These will be combined into a single instruction set that Copilot uses to rank incoming emails.
+
+## Low Priority Instructions
+
+```text
+- Messages related to company-wide announcements (e.g., "All Hands" meetings)
+- Newsletters or marketing blasts (internal "news you can use", updates, etc.)
+- Automated digests (daily build summaries, reminders, etc.)
+- Messages where I'm CC'd or FYI-only threads
+- Messages where I'm only copied, not directly addressed
+- "Just keeping you in the loop" messages that don't require action from me
+- Recurring status updates with no new deliverables or decisions required
+- "For your reference" docs or whitepapers with no deadlines
+- Invitations to optional webinars or training sessions outside of my immediate scope. My current scope: <SCOPE/PROJECT/INITIATIVE DETAILS>
+- Social or community messages (e.g., Team's shoutouts, Team's threads, etc.)
+- Low-impact or deadline-free communications
+- Ping reminders without context or attachments
+```
+
+Combine this with the high-priority instruction to give Copilot the full picture of what should float to the top versus what can wait.
+
+> [!TIP]
+> Consider any out-of-scope responsibilities to include as low-priority signals. For example, a software engineer might deprioritize messages about marketing campaigns, while a sales manager could push down internal IT notifications.


### PR DESCRIPTION
This pull request updates the business communication prompts for Outlook Copilot to provide more actionable guidance on email prioritization. The changes clarify the category description and introduce new templates for teaching Copilot which emails should be surfaced as high or low priority.

**Business Communication Prompt Enhancements:**

* Updated the business communication category description in `README.md` to clarify that it now covers email drafting and stakeholder messaging helpers, not just Outlook Copilot rules.
* Added two new prompt templates to `prompts/business/communication/README.md`:
  - Outlook Copilot High-Priority Instructions: Helps users define rules for surfacing urgent or important emails. [[1]](diffhunk://#diff-5180c03e3e5fc3f10d2b98e1b1be76d264e315fc792d14e866787ca53494bbfbR10-R11) [[2]](diffhunk://#diff-8fdfc122436e9d80be9ed01bd46a145418dadaeb0bd49372af88bc6b9ad99d6bR1-R41)
  - Outlook Copilot Low-Priority Instructions: Provides guidance on deprioritizing FYI-only or low-impact messages. [[1]](diffhunk://#diff-5180c03e3e5fc3f10d2b98e1b1be76d264e315fc792d14e866787ca53494bbfbR10-R11) [[2]](diffhunk://#diff-aa020df8382d7c0726c3b6ef6a5bafa823fbf700574688f0715109652a650f38R1-R41)
* Each new template includes example instructions and tips for tailoring prioritization to individual roles, making it easier for users to customize Copilot’s behavior. [[1]](diffhunk://#diff-8fdfc122436e9d80be9ed01bd46a145418dadaeb0bd49372af88bc6b9ad99d6bR1-R41) [[2]](diffhunk://#diff-aa020df8382d7c0726c3b6ef6a5bafa823fbf700574688f0715109652a650f38R1-R41)