### PR TITLE
Add issue management prompts for GitHub bug reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ All prompts live under [`prompts/`](prompts/README.md). The folder categories ar
 | Content - Writing      | `prompts/content/`                | Outlining, SEO metadata, feature images, conclusions          |
 | Content - Reviewing    | `prompts/content/reviewing/`      | Language quality checks, topic accuracy, readability feedback |
 | Social Media           | `prompts/social/`                 | Conversation-starting posts and image prompts                 |
-| Coding                 | `prompts/coding/`                 | Release-note system prompt ready for changelog inputs         |
+| Coding                 | `prompts/coding/`                 | Release notes plus GitHub bug-report templates                |
 | Knowledge Retrieval    | `prompts/knowledge/`              | Context-grounded answering for RAG setups                     |
 | Business Communication | `prompts/business/communication/` | Email drafting, stakeholder messaging helpers                 |
 | Career Development     | `prompts/career/development/`     | Performance reviews, growth plans, and professional coaching  |

--- a/prompts/coding/issue-management/README.md
+++ b/prompts/coding/issue-management/README.md
@@ -1,0 +1,8 @@
+---
+title: Issue Management
+description: Prompts that streamline capturing, triaging, and tracking software bugs.
+---
+
+# Issue Management
+
+- [GitHub Bug Report](github-bug-report.md) - generate a ready-to-file GitHub issue with consistent title and reproduction sections.

--- a/prompts/coding/issue-management/github-bug-report.md
+++ b/prompts/coding/issue-management/github-bug-report.md
@@ -27,7 +27,7 @@ Use the following issue template:
 
 - Title: "[Bug]: ..."
 - Steps to reproduce: "Describe accurately how we can reproduce/verify the bug"
-- Expected behavior: "A clear and concise description of what you expected to happened"
+- Expected behavior: "A clear and concise description of what you expected to happen"
 - Actual behavior: "A clear and concise description of what actually happened"
 ```
 

--- a/prompts/coding/issue-management/github-bug-report.md
+++ b/prompts/coding/issue-management/github-bug-report.md
@@ -1,0 +1,35 @@
+---
+title: GitHub Bug Report
+category: coding
+subcategory: issue-management
+description: Turn a short problem summary into a formatted GitHub bug ticket using a consistent template.
+llm_tools:
+  - ChatGPT
+  - Microsoft Copilot
+inputs:
+  - Brief description of the issue
+  - Detailed reproduction steps
+  - Expected vs. actual behavior
+---
+
+# GitHub Bug Report
+
+Use this prompt when you want the model to draft a clean GitHub issue that matches your bug template. It is especially helpful when you know the reproduction steps and just need consistent formatting before sharing with maintainers.
+
+## Prompt
+
+```text
+Generate a GitHub bug report for "<describe issue>".
+
+<Detailed description of how the issue can be reproduced>.
+
+Use the following issue template:
+
+- Title: "[Bug]: ..."
+- Steps to reproduce: "Describe accurately how we can reproduce/verify the bug"
+- Expected behavior: "A clear and concise description of what you expected to happened"
+- Actual behavior: "A clear and concise description of what actually happened"
+```
+
+> [!TIP]
+> Replace the placeholders with your actual description and reproduction steps. Copilot or ChatGPT will fill in the issue sections, which you can then paste into your repository.


### PR DESCRIPTION
This pull request enhances the coding prompts by introducing a new section for issue management, specifically focused on generating GitHub bug reports. It updates documentation to reflect these additions and provides a clear template for drafting consistent bug tickets.

**Documentation and Prompt Additions:**

* Added a new `issue-management` category under `prompts/coding/` with a dedicated `README.md` describing its purpose and listing the GitHub bug report prompt.
* Introduced a detailed `github-bug-report.md` prompt, including a template for generating formatted GitHub issues and guidance for using LLM tools like ChatGPT and Copilot.

**Documentation Updates:**

* Updated the main `README.md` to clarify that the coding prompts now include both release notes and GitHub bug-report templates.