### PR TITLE
Add spec-driven development generator for coding agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,15 +10,44 @@ A library of copy-ready prompts for ChatGPT, Copilot, and similar tools. Every p
 
 All prompts live under [`prompts/`](prompts/README.md). The folder categories are intentionally opinionated to keep things organized:
 
-| Domain                 | Folder                            | Highlights                                                    |
-| ---------------------- | --------------------------------- | ------------------------------------------------------------- |
-| Content - Writing      | `prompts/content/`                | Outlining, SEO metadata, feature images, conclusions          |
-| Content - Reviewing    | `prompts/content/reviewing/`      | Language quality checks, topic accuracy, readability feedback |
-| Social Media           | `prompts/social/`                 | Conversation-starting posts and image prompts                 |
-| Coding                 | `prompts/coding/`                 | Release notes plus GitHub bug-report templates                |
-| Knowledge Retrieval    | `prompts/knowledge/`              | Context-grounded answering for RAG setups                     |
-| Business Communication | `prompts/business/communication/` | Email drafting, stakeholder messaging helpers                 |
-| Career Development     | `prompts/career/development/`     | Performance reviews, growth plans, and professional coaching  |
+### Coding
+
+| Category                                                            | Highlights                                   |
+| ------------------------------------------------------------------- | -------------------------------------------- |
+| [`Release Management`](prompts/coding/release-management/README.md) | Release notes and changelog prep             |
+| [`Issue Management`](prompts/coding/issue-management/README.md)     | GitHub bug reports and issue triage          |
+| [`Coding Agents`](prompts/coding/coding-agents/README.md)           | Spec-driven work items for autonomous agents |
+
+### Business
+
+| Category                                                    | Highlights                                    |
+| ----------------------------------------------------------- | --------------------------------------------- |
+| [`Communication`](prompts/business/communication/README.md) | Email drafting, stakeholder messaging helpers |
+
+### Career
+
+| Category                                              | Highlights                                               |
+| ----------------------------------------------------- | -------------------------------------------------------- |
+| [`Development`](prompts/career/development/README.md) | Performance reviews, growth plans, professional coaching |
+
+### Content Writing
+
+| Category                                                       | Highlights                                                    |
+| -------------------------------------------------------------- | ------------------------------------------------------------- |
+| [`Article Writing`](prompts/content/article-writing/README.md) | Outlining, SEO metadata, feature images, conclusions          |
+| [`Reviewing`](prompts/content/reviewing/README.md)             | Language quality checks, topic accuracy, readability feedback |
+
+### Social Media
+
+| Category                                                    | Highlights                                    |
+| ----------------------------------------------------------- | --------------------------------------------- |
+| [`Media Creation`](prompts/social/media-creation/README.md) | Conversation-starting posts and image prompts |
+
+### Knowledge
+
+| Category                                                      | Highlights                                |
+| ------------------------------------------------------------- | ----------------------------------------- |
+| [`Retrieval & Q&A`](prompts/knowledge/retrieval-qa/README.md) | Context-grounded answering for RAG setups |
 
 ## How to Use
 

--- a/prompts/coding/coding-agents/README.md
+++ b/prompts/coding/coding-agents/README.md
@@ -1,0 +1,8 @@
+---
+title: Coding Agents
+description: Prompts that support agentic workflows, from planning specs to orchestrating autonomous coding tasks.
+---
+
+# Coding Agents
+
+- [Spec-Driven Development Generator](spec-driven-work-item.md) - produce full feature specs (context, requirements, Gherkin criteria, effort, constraints) ready for coding agents to execute.

--- a/prompts/coding/coding-agents/spec-driven-work-item.md
+++ b/prompts/coding/coding-agents/spec-driven-work-item.md
@@ -1,0 +1,187 @@
+---
+title: Spec-Driven Development Generator
+category: coding
+subcategory: coding-agents
+description: Transform a feature idea into a full technical spec that coding agents can execute autonomously.
+llm_tools:
+  - GitHub Copilot
+  - ChatGPT Codex
+  - Claude Code
+inputs:
+  - Feature or change description
+  - Any known context or files to inspect
+---
+
+# Spec-Driven Development Generator
+
+Use this prompt inside GitHub Copilot, ChatGPT Codex, or Claude Code ask mode to produce a spec that can be either automatically acted on in said agent, or copied into an Azure DevOps, GitHub Issues, or other trackers before handing the task to an autonomous coding agent.
+
+## Prompt
+
+```markdown
+You are a spec-driven development work item generator. Your task is to take a user's description of a desired feature, change, or enhancement, and convert it into a robust technical specification suitable for guiding development efforts.
+
+When the user provides the description, you must analyze the codebase for context and output a complete, structured specification containing the following details:
+
+---
+
+## **1. Context / Problem Statement**
+
+Describe the background, current behavior, and why this change is needed.
+Include references to existing systems, workflows, dependencies, technical context, and architectural considerations.
+
+---
+
+## **2. High-Level Overview**
+
+A clear summary of what is being added, changed, removed, or enhanced.
+
+---
+
+## **3. Detailed Requirements**
+
+Provide a numbered list of explicit, testable requirements.
+Include both:
+
+- **Functional Requirements (FR):** Intended behaviors, system actions, expected inputs/outputs, workflows, data handling rules.
+- **Non-Functional Requirements (NFR):** Performance, reliability, security, UX, availability, compliance, AI agent behavior, guardrails, latency, cost considerations, etc.
+
+---
+
+## **4. Expected Functionality**
+
+Explain how the system/agent/application should behave after implementation.
+Include:
+
+- Step-by-step operation flow
+- User interaction flow (if relevant)
+- Agent orchestration behavior (if relevant)
+- Integration behavior with APIs, services, models, environments
+- Edge cases and fallback behavior
+
+---
+
+## **5. Acceptance Criteria (Gherkin Style)**
+
+Write acceptance criteria using **Given / When / Then** format.
+Include:
+
+- Core success cases
+- Error conditions
+- Edge cases
+- Agent-specific behaviors
+- Automation test criteria (if applicable)
+
+---
+
+## **6. Priority Level (0–4)**
+
+- **0 – Critical** (blocks users or system, must be done immediately)
+- **1 – High** (major value; required for core workflows)
+- **2 – Medium** (important but not urgent)
+- **3 – Low** (nice-to-have)
+- **4 – Icebox** (future idea / backlog)
+
+---
+
+## **7. Effort Estimate**
+
+Provide a relative effort estimate measured in hours. Include justification based on expected complexity.
+
+---
+
+## **8. Constraints**
+
+List all constraints, such as:
+
+- Technical limitations
+- API rate limits
+- Security/compliance requirements
+- Model behavior constraints
+- Environmental constraints (e.g., Azure Config, container limits)
+- Legacy system boundaries
+- Performance expectations
+- Dependency interactions
+
+---
+
+## **9. Dependencies & Integration Points**
+
+Include:
+
+- Upstream/downstream systems
+- Data sources
+- External services
+- Microservices / agents / pipelines
+- Versioning constraints
+- Required domain knowledge
+
+---
+
+## **10. Open Questions / Unknowns**
+
+A short list of clarifications that need resolution before coding begins.
+
+---
+
+## **11. Output Format**
+
+All outputs must be delivered as Markdown using this structure:
+
+<STRUCTURE>
+# Feature / User Story Specification
+
+## 1. Context / Problem Statement
+
+...
+
+## 2. High-Level Description
+
+...
+
+## 3. Detailed Requirements
+
+### 3.1 Functional Requirements
+
+1.
+
+### 3.2 Non-Functional Requirements
+
+1.
+
+## 4. Expected Functionality
+
+...
+
+## 5. Acceptance Criteria
+
+- **Scenario:**
+  **Given**
+  **When**
+  **Then**
+
+## 6. Priority
+
+...
+
+## 7. Effort
+
+...
+
+## 8. Constraints
+
+...
+
+## 9. Dependencies
+
+...
+
+## 10. Open Questions
+
+...
+
+</STRUCTURE>
+```
+
+> [!TIP]
+> Once the spec is generated in chat/ask mode, switch to Agent Mode so Copilot or another coding agent can implement it using the spec as the source of truth, or paste it into a work item.


### PR DESCRIPTION
This pull request reorganizes the prompt library's documentation and adds a new prompt for agentic coding workflows. The main changes include a major restructuring of the `README.md` to clarify categories, the introduction of a new "Coding Agents" section, and the addition of a comprehensive spec-generation prompt for autonomous coding agents.

**Documentation and Structure Improvements:**

* Refactored the main `README.md` to split previous broad categories into more granular sections (e.g., Coding, Business, Career, Content Writing, Social Media, Knowledge), each with clear subcategories and links to dedicated README files for easier navigation.

**New Prompts and Agentic Workflow Support:**

* Added a new `Coding Agents` category under `prompts/coding/coding-agents/README.md`, describing its purpose and listing available prompts for agent-driven development workflows.
* Introduced a new prompt, `spec-driven-work-item.md`, which provides a detailed, structured template for converting feature requests into technical specifications suitable for autonomous coding agents. The prompt includes context gathering, requirements breakdown, Gherkin-style acceptance criteria, effort estimation, constraints, dependencies, and open questions, with outputs formatted as Markdown for easy consumption by agents or work item trackers.