### PR TITLE
Add research hypothesis generator prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,12 @@ All prompts live under [`prompts/`](prompts/README.md). The folder categories ar
 | [`Article Writing`](prompts/content/article-writing/README.md) | Outlining, SEO metadata, feature images, conclusions          |
 | [`Reviewing`](prompts/content/reviewing/README.md)             | Language quality checks, topic accuracy, readability feedback |
 
+### Ideation
+
+| Category                                                    | Highlights                                               |
+| ----------------------------------------------------------- | -------------------------------------------------------- |
+| [`Brainstorming`](prompts/ideation/brainstorming/README.md) | Idea generation, hypothesis framing, and experimentation |
+
 ### Social Media
 
 | Category                                                    | Highlights                                    |

--- a/prompts/ideation/brainstorming/README.md
+++ b/prompts/ideation/brainstorming/README.md
@@ -1,0 +1,8 @@
+---
+title: Idea Generation
+description: Prompts that spark creative exploration, experiments, and MVP validation.
+---
+
+# Idea Generation
+
+- [Research Hypothesis Generator](research-hypotheses.md) - produce structured, testable hypotheses with rationale, testing methods, and business implications.

--- a/prompts/ideation/brainstorming/research-hypotheses.md
+++ b/prompts/ideation/brainstorming/research-hypotheses.md
@@ -1,7 +1,7 @@
 ---
 title: Research Hypothesis Generator
 category: ideation
-subcategory: hypothesis-testing
+subcategory: brainstorming
 description: Turn customer data or internal observations into structured, testable hypotheses for MVP experiments.
 llm_tools:
   - ChatGPT

--- a/prompts/ideation/brainstorming/research-hypotheses.md
+++ b/prompts/ideation/brainstorming/research-hypotheses.md
@@ -1,0 +1,66 @@
+---
+title: Research Hypothesis Generator
+category: ideation
+subcategory: hypothesis-testing
+description: Turn customer data or internal observations into structured, testable hypotheses for MVP experiments.
+llm_tools:
+  - ChatGPT
+  - Microsoft Copilot
+inputs:
+  - Product or initiative description
+  - Goal or desired outcome
+  - Relevant customer data or insights
+---
+
+# Research Hypothesis Generator
+
+Use this prompt when you want to frame experiments or MVPs around clear hypotheses. It works equally well for internal initiatives, feature ideas, or customer-facing changes.
+
+## Prompt
+
+```text
+Generate <N> research hypotheses based on the following context.
+
+Initiative:
+<Describe the product, service, or internal project>
+
+Goal:
+<State the desired outcome or metric to improve>
+
+Customer or User Data:
+<Summarize relevant observations, telemetry, or qualitative insights>
+
+For each hypothesis:
+- State the hypothesis clearly.
+- Explain the rationale behind it.
+- Suggest a method to test it.
+- Describe potential business or product implications if proven true.
+
+Ensure the hypotheses are specific, testable, and directly tied to improving the product, customer experience, or internal process.
+```
+
+> [!TIP]
+> Swap “N” for any number of experiments you need, and tailor the testing methods to match the tools or analytics stack your team relies on.
+
+## Example
+
+```text
+Generate 3 research hypotheses based on the following context.
+
+Initiative:
+Improving the onboarding experience for new users of our mobile app.
+
+Goal:
+Increase the 7-day retention rate by 15%.
+
+Customer or User Data:
+Recent user interviews indicate that many new users feel overwhelmed by the number of features presented during onboarding.
+
+For each hypothesis:
+- State the hypothesis clearly.
+- Explain the rationale behind it.
+- Suggest a method to test it.
+- Describe potential business or product implications if proven true.
+
+Ensure the hypotheses are specific, testable, and directly tied to improving the product, customer experience, or internal process.
+```


### PR DESCRIPTION
This pull request introduces a new "Ideation" category to the prompts documentation, focusing on creative exploration and hypothesis-driven experimentation. The main addition is a structured "Research Hypothesis Generator" prompt, which helps teams turn observations and customer data into actionable, testable hypotheses for product or process improvements.

**Documentation and Prompt Additions:**

* Added an "Ideation" section to the main `README.md`, including a new table entry for `Brainstorming` prompts and a link to its documentation.
* Created `prompts/ideation/brainstorming/README.md` with an overview of idea generation prompts and a link to the new "Research Hypothesis Generator."

**New Prompt for Hypothesis Framing:**

* Added `prompts/ideation/brainstorming/research-hypotheses.md`, detailing a "Research Hypothesis Generator" prompt. This includes instructions, required inputs, example usage, and tips for customization, designed to help teams generate structured, testable hypotheses from customer or internal data.