### PR TITLE
Add Meeting Notes Summary Generator prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,10 @@ All prompts live under [`prompts/`](prompts/README.md). The folder categories ar
 
 ### Business
 
-| Category                                                    | Highlights                                    |
-| ----------------------------------------------------------- | --------------------------------------------- |
-| [`Communication`](prompts/business/communication/README.md) | Email drafting, stakeholder messaging helpers |
+| Category                                                    | Highlights                                         |
+| ----------------------------------------------------------- | -------------------------------------------------- |
+| [`Communication`](prompts/business/communication/README.md) | Email drafting, stakeholder messaging helpers      |
+| [`Meetings`](prompts/business/meetings/README.md)           | Structured recaps of recorded/transcribed sessions |
 
 ### Career
 
@@ -45,9 +46,9 @@ All prompts live under [`prompts/`](prompts/README.md). The folder categories ar
 
 ### Social Media
 
-| Category                                                    | Highlights                                    |
-| ----------------------------------------------------------- | --------------------------------------------- |
-| [`Media Creation`](prompts/social/media-creation/README.md) | Conversation-starting posts and image prompts |
+| Category                                                    | Highlights                                                        |
+| ----------------------------------------------------------- | ----------------------------------------------------------------- |
+| [`Media Creation`](prompts/social/media-creation/README.md) | Conversation-starting posts on LinkedIn, and social image prompts |
 
 ### Knowledge
 

--- a/prompts/business/meetings/README.md
+++ b/prompts/business/meetings/README.md
@@ -1,0 +1,8 @@
+---
+title: Meetings
+description: Prompts that help document discussions, capture progress, and align next steps.
+---
+
+# Meetings
+
+- [Meeting Notes Summary Generator](meeting-notes-summary.md) - turn recordings or transcripts into structured notes with participants, purpose, goals, and actions.

--- a/prompts/business/meetings/README.md
+++ b/prompts/business/meetings/README.md
@@ -5,4 +5,4 @@ description: Prompts that help document discussions, capture progress, and align
 
 # Meetings
 
-- [Meeting Notes Summary Generator](meeting-notes-summary.md) - turn recordings or transcripts into structured notes with participants, purpose, goals, and actions.
+- [Meeting Notes Summary Generator](meeting-notes-summary.md) - Convert meeting transcripts or recordings into structured notes with participants, purpose, goals, and actions.

--- a/prompts/business/meetings/meeting-notes-summary.md
+++ b/prompts/business/meetings/meeting-notes-summary.md
@@ -19,7 +19,7 @@ Use this prompt when you have a recorded or transcribed meeting and need a clean
 ## Prompt
 
 ```text
-You are an AI assistant that supports recorded/transcribed meetings with note generation by detailing out the outputs.
+You are an AI assistant that supports recorded/transcribed meetings with note generation by detailing the outputs.
 
 You adhere to the following structure:
 

--- a/prompts/business/meetings/meeting-notes-summary.md
+++ b/prompts/business/meetings/meeting-notes-summary.md
@@ -1,0 +1,49 @@
+---
+title: Meeting Notes Summary Generator
+category: business
+subcategory: meetings
+description: Convert meeting transcripts or recordings into structured notes with participants, purpose, progress, and next steps.
+llm_tools:
+  - Microsoft Teams (Recap / Copilot)
+  - ChatGPT
+inputs:
+  - Participant names
+  - Transcript or summary of the discussion
+  - Any known goals or action items
+---
+
+# Meeting Notes Summary Generator
+
+Use this prompt when you have a recorded or transcribed meeting and need a clean summary that stakeholders can scan quickly. It mirrors the structure used in Teams Recap and custom summaries.
+
+## Prompt
+
+```text
+You are an AI assistant that supports recorded/transcribed meetings with note generation by detailing out the outputs.
+
+You adhere to the following structure:
+
+👥 Participants
+> Comma-separated list of all participant names
+
+📑 Purpose
+> A general summary of what the purpose of the meeting was (e.g., "A session to discuss <TOPIC>, focusing on <FOCUS AREA>, and providing insights on <GUIDANCE>").
+
+💡 Key Discussion Points
+> Bullet list sharing key updates and the overall initiative status.
+
+📈 Progress
+> If applicable, add a sub-section for each participant covering what they accomplished and any impediments.
+
+🎯 Goals
+> Bullet list sharing what the team plans to achieve next.
+
+❓ Open Actions
+> Bullet list reviewing or updating next steps and deadlines.
+
+Context / Transcript:
+<Paste the meeting transcript, call notes, or key bullets here>
+```
+
+> [!TIP]
+> When using Teams, paste this prompt into the recap summary window or Copilot chat, then drop in the automatically generated transcript to get consistent notes every time.


### PR DESCRIPTION
This pull request introduces a new "Meetings" category under business prompts, with a focus on helping users generate structured meeting notes from recordings or transcripts. It updates documentation to reflect the new category and provides a detailed prompt template for meeting note summaries. The most important changes are grouped below:

**Documentation updates:**

* Added a new `Meetings` category to the business prompts section in `README.md`, including a description and highlights of its purpose.

**New meeting notes prompt:**

* Created `prompts/business/meetings/README.md` to introduce the Meetings category and link to its first prompt.
* Added `prompts/business/meetings/meeting-notes-summary.md`, providing a structured prompt for generating meeting notes, including sections for participants, purpose, key points, progress, goals, and open actions, with usage tips for Microsoft Teams and ChatGPT.