### PR TITLE
Add Monthly Impact Journal prompt to enhance reflective journaling

### DIFF
--- a/prompts/journaling/reflection/README.md
+++ b/prompts/journaling/reflection/README.md
@@ -6,3 +6,4 @@ description: Prompts that guide personal or professional retrospectives with str
 # Reflection
 
 - [Weekly Impact Journal](weekly-impact-journal.md) - generate a citation-backed weekly recap that connects every win, blocker, and lesson to your business or career focus areas.
+- [Monthly Impact Journal](monthly-impact-journal.md) - synthesize multiple weekly journals into a monthly narrative with clear citations and reuse guidance.

--- a/prompts/journaling/reflection/monthly-impact-journal.md
+++ b/prompts/journaling/reflection/monthly-impact-journal.md
@@ -1,0 +1,69 @@
+---
+title: Monthly Impact Journal
+category: journaling
+subcategory: reflection
+description: Roll up multiple Weekly Impact Journals into a single, citation-backed monthly summary aligned to your priorities.
+llm_tools:
+  - Microsoft 365 Copilot
+  - Loop or OneNote
+  - SharePoint or OneDrive
+  - Teams
+inputs:
+  - Month timeframe (start and end dates)
+  - Weekly journal documents or links
+  - Core priorities or focus areas
+  - Key initiatives or accounts to spotlight
+  - Citation format or reference style
+  - Instructions for summarizing impact vs. effort
+---
+
+# Monthly Impact Journal
+
+Use this prompt to stitch together your [Weekly Impact Journals](./weekly-impact-journal.md) into a single narrative that shows compounding impact, persistent risk, and lessons learned through the month.
+
+## Context
+
+Feed the model the month you want to summarize, attach or paste each weekly journal, and restate the core priorities you are measured against. This ensures the model cites only the supplied journals and keeps the narrative tethered to the same focus areas you share with business or career audiences.
+
+## Prompt
+
+```text
+Using the following weekly journals, generate a monthly summary that captures the following details:
+
+- What went well this month?
+- What didn't go well this month?
+- What were my biggest challenges this month, and how did I address them?
+- What did I learn this month?
+
+Only cite relevant sources from the weekly journals to support each point made in the summary. Ensure each section is specific and relevant to my core priorities, and avoid generic statements.
+
+---
+
+For additional context, the journal should align with my core focus areas:
+
+- <FOCUS AREA 1>
+  - <DESCRIPTION>
+- <FOCUS AREA 2>
+  - <DESCRIPTION>
+
+---
+
+Important interactions to consider as context for this month:
+- <Initiative or highlight + why it matters>
+
+---
+
+Here are the weekly journals to reference:
+
+- <WEEKLY JOURNAL 1 OR LINK>
+```
+
+> [!TIP]
+> If using M365 Copilot, attach or add the files from your business OneDrive, SharePoint, or Loop workspace so it can reference them directly.
+
+## Tips
+
+- Run the [Weekly Impact Journal](weekly-impact-journal.md) prompt every Friday so you always have clean inputs for the month-end rollup.
+- Store weekly journals in a Loop workspace or OneNote section named after the quarter—Copilot can reference them quickly when the links share friendly titles.
+- When highlighting challenges, reference both the week the issue appeared and the week you mitigated it so reviewers can trace closure.
+- Pair this monthly summary with the [Performance Review Impact Assessment](../../career/development/performance-review-impact-assessment.md) to accelerate quarterly or annual narratives.

--- a/prompts/journaling/reflection/weekly-impact-journal.md
+++ b/prompts/journaling/reflection/weekly-impact-journal.md
@@ -41,6 +41,7 @@ Always cite relevant sources from my calendar, emails, Teams, and files to suppo
 ---
 
 Here's an example:
+
 <EXAMPLE>
 **What went well this week?**
 
@@ -71,6 +72,7 @@ Important interactions to consider as context for this week:
 
 ## Tips
 
+- Run this prompt at the end of each week to maintain a consistent record of your impact and challenges.
 - Pair this journal with the [Performance Review Impact Assessment](../../career/development/performance-review-impact-assessment.md) prompt to fast-track quarterly or annual submissions.
 - If your business audience expects executive-ready bullets, keep each citation visible so they can drill into the source material without exporting additional notes.
 - Maintain a running "Important interactions" list during the week; paste it into the prompt so Copilot knows which calls, escalations, or files cannot be missed.


### PR DESCRIPTION
This pull request introduces a new monthly reflection prompt and enhances the journaling workflow to support more structured, citation-backed retrospectives. The most significant change is the addition of the `Monthly Impact Journal`, which synthesizes weekly reflections into a comprehensive monthly summary aligned to user priorities. Additional improvements clarify usage tips and encourage consistent record-keeping.

**New monthly reflection workflow:**

* Added the `Monthly Impact Journal` prompt in `monthly-impact-journal.md`, enabling users to roll up multiple weekly journals into a single, citation-backed monthly summary focused on core priorities and initiatives.
* Updated the `README.md` to include the new `Monthly Impact Journal`, making it discoverable alongside existing prompts.

**Enhancements to weekly journaling:**

* Added a tip in `weekly-impact-journal.md` advising users to run the prompt at the end of each week for consistent impact tracking.
* Improved example formatting in `weekly-impact-journal.md` for clarity when reviewing what went well during the week.