### PR TITLE
Add Business Goal Setting prompt for OKRs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,7 @@
 When adding a new prompt:
 
 - **Verify Uniqueness**: Ensure a prompt does not already exist for the intended purpose.
-- **Choose Correct Folder**: Place the new prompt in the appropriate domain/sub-domain folder.
+- **Choose Correct Folder**: Place the new prompt in the appropriate domain/sub-domain folder. You can find these in the `prompts/` directory.
 - **Use Frontmatter**: Include all required metadata in the frontmatter.
 - **Structure the Content**: Follow the established format: context, prompt, example, and tips.
 - **Link in README**: Update the nearest `README.md` to include a link and description of the new prompt.

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ All prompts live under [`prompts/`](prompts/README.md). The folder categories ar
 | ----------------------------------------------------------- | -------------------------------------------------- |
 | [`Communication`](prompts/business/communication/README.md) | Email drafting, stakeholder messaging helpers      |
 | [`Meetings`](prompts/business/meetings/README.md)           | Structured recaps of recorded/transcribed sessions |
+| [`Goal Setting`](prompts/business/goal-setting/README.md)   | Structured OKR drafting and target tracking        |
 
 ### Career
 
@@ -33,8 +34,8 @@ All prompts live under [`prompts/`](prompts/README.md). The folder categories ar
 
 ### Journaling
 
-| Category                                             | Highlights                                                          |
-| ---------------------------------------------------- | ------------------------------------------------------------------- |
+| Category                                                | Highlights                                                           |
+| ------------------------------------------------------- | -------------------------------------------------------------------- |
 | [`Reflection`](prompts/journaling/reflection/README.md) | Weekly and monthly impact journals for business and career alignment |
 
 ### Content Writing

--- a/prompts/business/goal-setting/README.md
+++ b/prompts/business/goal-setting/README.md
@@ -1,0 +1,10 @@
+---
+title: Business Goal Setting
+description: Prompts for translating strategy notes into actionable objectives and measurable outcomes.
+---
+
+# Business Goal Setting
+
+These prompts accelerate planning cycles by turning high-level priorities into structured OKRs or milestone-driven targets.
+
+- [OKR Planning Template](okr-planning-template.md) - convert focus areas, success signals, and dependencies into clear objectives with measurable key results.

--- a/prompts/business/goal-setting/okr-planning-template.md
+++ b/prompts/business/goal-setting/okr-planning-template.md
@@ -56,7 +56,7 @@ Create OKRs using this structure:
 Guidelines:
 - Group related focus areas together so each objective feels meaningful and not redundant.
 - When a focus area already looks like a key result, promote it into the right section and enrich it with metrics or milestones.
-- Suggest success criteria even if the user only supplied directionally (e.g., "reduce X" -> specify a realistic target or range). If data is missing, state the placeholder metric so the user can fill it in.
+- Suggest success criteria even if the user only supplied direction (e.g., "reduce X" -> specify a realistic target or range). If data is missing, state the placeholder metric so the user can fill it in.
 - Incorporate collaboration or customer-facing elements when the context implies cross-functional work.
 - Keep wording crisp enough to paste into a planning doc without edits.
 

--- a/prompts/business/goal-setting/okr-planning-template.md
+++ b/prompts/business/goal-setting/okr-planning-template.md
@@ -1,0 +1,65 @@
+---
+title: OKR Planning Template
+category: business
+subcategory: goal-setting
+description: Transform raw focus areas, success criteria, and risks into polished objectives and measurable key results for any role or team.
+llm_tools:
+  - ChatGPT
+  - Microsoft Copilot
+inputs:
+  - Role or team name and scope
+  - Planning period or fiscal timeframe
+  - Company, product, or customer priorities
+  - Draft objectives, focus areas, or problem statements
+  - Success measures, metrics, or targets
+  - Dependencies, risks, and collaboration notes
+---
+
+# OKR Planning Template
+
+Use this template when you need to turn messy planning notes into clear objectives and quantifiable key results. The model ingests all of your context (draft objectives, focus areas, success signals, dependencies) and responds with OKRs that balance ambition with feasibility.
+
+## Prompt
+
+```text
+You are an AI strategy partner that helps <ROLE OR TEAM NAME> shape clear, measurable OKRs for the upcoming <PLANNING PERIOD>. OKRs must connect daily execution to broader business goals.
+
+Always do the following:
+- Read every part of the provided context before responding.
+- Ensure each objective is concise, business-aligned, and action-oriented.
+- Craft key results that are specific, quantifiable, time-bound, and tied to meaningful metrics.
+- Highlight collaboration needs, risks, or assumptions when they influence success.
+- Respect the tone, terminology, and constraints supplied by the user - never invent details.
+
+You will be given:
+- Planning timeframe, org mission, and role/owner details.
+- Draft objectives or focus areas that need refinement.
+- Success measures, KPIs, or qualitative signals.
+- Dependencies, risks, resource limits, and cross-functional partners.
+
+Create OKRs using this structure:
+
+# Objective: <Title>
+
+## Summary
+1-2 sentences linking the objective to the strategic goals and why it matters this period.
+
+## Key Results
+- KR1: Describe the measurable outcome, include target metric + deadline.
+- KR2: "
+- KR3: "
+(Add KR4 if needed, but keep the list focused.)
+
+## Dependencies & Collaboration
+- Note key partners, assumptions, or risks that must be tracked.
+
+Guidelines:
+- Group related focus areas together so each objective feels meaningful and not redundant.
+- When a focus area already looks like a key result, promote it into the right section and enrich it with metrics or milestones.
+- Suggest success criteria even if the user only supplied directionally (e.g., "reduce X" -> specify a realistic target or range). If data is missing, state the placeholder metric so the user can fill it in.
+- Incorporate collaboration or customer-facing elements when the context implies cross-functional work.
+- Keep wording crisp enough to paste into a planning doc without edits.
+
+Context:
+<Paste planning notes, draft objectives, metrics, and constraints here>
+```


### PR DESCRIPTION
This pull request introduces a new "Goal Setting" prompt category focused on business OKR planning, and updates documentation to reflect the addition. The main changes are the creation of a new template for OKR planning, updates to documentation to reference this new category, and improvements to the clarity and structure of prompt organization instructions.

**Business Goal Setting Prompt Addition:**

* Added a new `goal-setting` category under `prompts/business/` with a dedicated `README.md` describing its purpose and linking to the OKR planning template.
* Created `okr-planning-template.md` containing a detailed prompt for transforming planning notes into structured OKRs, including metadata, instructions, and a copy-paste prompt for users.

**Documentation Updates:**

* Updated the main `README.md` to list "Goal Setting" as a prompt category under business, with a brief description and link to the new folder.
* Improved table formatting in the journaling section of `README.md` for consistency.

**Contributor Guidance Improvements:**

* Enhanced the instructions in `AGENTS.md` for adding new prompts, clarifying that domain/sub-domain folders can be found in the `prompts/` directory.