### PR TITLE
Add Product Feedback Work Item template to streamline customer feedback

### DIFF
--- a/prompts/coding/issue-management/README.md
+++ b/prompts/coding/issue-management/README.md
@@ -6,3 +6,4 @@ description: Prompts that streamline capturing, triaging, and tracking software 
 # Issue Management
 
 - [GitHub Bug Report](github-bug-report.md) - generate a ready-to-file GitHub issue with consistent title and reproduction sections.
+- [Product Feedback Work Item](product-feedback-work-item.md) - translate customer findings into engineering-ready feedback with title, verbatim, ask, impact, and workaround.

--- a/prompts/coding/issue-management/product-feedback-work-item.md
+++ b/prompts/coding/issue-management/product-feedback-work-item.md
@@ -1,0 +1,41 @@
+---
+title: Product Feedback Work Item
+category: coding
+subcategory: issue-management
+description: Convert raw customer observations into a structured engineering feedback ticket with title, verbatim, ask, impact, and workaround fields.
+llm_tools:
+  - ChatGPT
+  - Microsoft Copilot
+inputs:
+  - Product or feature area
+  - Customer description plus reproduction details
+  - Desired change or remediation steps
+  - Business/customer impact details
+  - Known workarounds or mitigation ideas
+---
+
+# Product Feedback Work Item
+
+Use this template whenever a customer surfaces a feature gap or product issue that should route into an engineering backlog (e.g., Azure DevOps). It helps you capture the narrative, define the ask, and make the impact measurable before sharing with product leads.
+
+## Prompt
+
+```text
+You are a product feedback specialist capturing customer insights for the <PRODUCT GROUP>. Examine the provided context and draft a concise feedback work item.
+
+Your response must include the following sections:
+- **Title**: Craft a clear, action-oriented title that product teams can triage.
+- **Verbatim**: Summarize the customer narrative with relevant quotes or specific usage details. Highlight affected scenarios, regions, or SKUs.
+- **Ask**: Explain exactly what the product group should build/fix, including functional and technical expectations plus how we can partner on validation.
+- **Impact**: Describe who is affected, severity, frequency, and downstream business/customer risks. Include metrics or counts when available.
+- **Workaround**: Document existing or proposed stopgap mitigations, noting limitations or support costs.
+
+Guidelines:
+- Pull only from the supplied context-do not invent facts.
+- Include both qualitative insight and any quantitative indicators that reinforce urgency.
+- Make the ask solution-oriented (e.g., "Expose billing usage API" instead of "Billing is broken").
+- If context lacks data for a section, insert a short TODO note so the requestor can fill it.
+
+Context:
+<Paste customer/partner notes, telemetry, chat logs, or reproduction details here>
+```

--- a/prompts/coding/issue-management/product-feedback-work-item.md
+++ b/prompts/coding/issue-management/product-feedback-work-item.md
@@ -31,7 +31,7 @@ Your response must include the following sections:
 - **Workaround**: Document existing or proposed stopgap mitigations, noting limitations or support costs.
 
 Guidelines:
-- Pull only from the supplied context-do not invent facts.
+- Pull only from the supplied context; do not invent facts.
 - Include both qualitative insight and any quantitative indicators that reinforce urgency.
 - Make the ask solution-oriented (e.g., "Expose billing usage API" instead of "Billing is broken").
 - If context lacks data for a section, insert a short TODO note so the requestor can fill it.


### PR DESCRIPTION
This pull request adds a new prompt template to streamline the process of converting customer feedback into actionable engineering work items. It introduces a structured approach for capturing product feedback, ensuring consistency and completeness when routing issues to engineering teams.

**New prompt for product feedback work items:**

* Added `product-feedback-work-item.md`, a template for translating customer findings into engineering-ready feedback with required fields: title, verbatim, ask, impact, and workaround.
* Updated `README.md` to include the new Product Feedback Work Item prompt in the list of available issue management prompts.