### PR TITLE
Add Evaluation category and Response Quality evaluator to enhance prompt/tool assessment

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,12 @@ All prompts live under [`prompts/`](prompts/README.md). The folder categories ar
 | [`Research Orchestration`](prompts/knowledge/research-orchestration/README.md) | Multi-agent research loops with observations, gap analysis, and synthesis |
 | [`Retrieval & Q&A`](prompts/knowledge/retrieval-qa/README.md)                  | Context-grounded answering for RAG setups                                 |
 
+### Evaluation
+
+| Category                                                       | Highlights                                                |
+| -------------------------------------------------------------- | --------------------------------------------------------- |
+| [`Response Quality`](prompts/evaluation/response-quality/README.md) | Relevancy and accuracy evaluators for AI-driven responses |
+
 ## How to Use
 
 1. Browse to a category folder and open its `README.md` for a quick description of every prompt inside.

--- a/prompts/evaluation/response-quality/README.md
+++ b/prompts/evaluation/response-quality/README.md
@@ -1,0 +1,8 @@
+---
+title: Response Quality
+description: Evaluator prompts that score whether AI-generated answers stay on topic and fulfill the request.
+---
+
+# Response Quality Evaluators
+
+- [Response Relevancy Evaluator](response-relevancy-evaluator.md) - confirm generated answers address the user query using only the supplied context.

--- a/prompts/evaluation/response-quality/response-relevancy-evaluator.md
+++ b/prompts/evaluation/response-quality/response-relevancy-evaluator.md
@@ -22,15 +22,15 @@ Use this evaluator prompt to quickly judge if a generated answer actually addres
 ```text
 We have been working on the following query:
 
-{query}
+<QUERY>
 
 We provided the following context:
 
-{context}
+<CONTEXT>
 
 And we have received the following response:
 
-{response}
+<RESPONSE>
 
 To ensure the response provided is relevant to the query, please answer the following question, including your reasoning:
 

--- a/prompts/evaluation/response-quality/response-relevancy-evaluator.md
+++ b/prompts/evaluation/response-quality/response-relevancy-evaluator.md
@@ -1,0 +1,70 @@
+---
+title: Response Relevancy Evaluator
+category: evaluation
+subcategory: response-quality
+description: Determine whether an AI response directly addresses the user query using the provided context.
+llm_tools:
+  - ChatGPT
+  - Claude
+  - Gemini
+inputs:
+  - User query or request
+  - Context supplied to the answering model (documents, notes, snippets)
+  - Model response to evaluate
+---
+
+# Response Relevancy Evaluator
+
+Use this evaluator prompt to quickly judge if a generated answer actually addresses the question while staying grounded in the supplied context. It works well for retrieval-augmented generation (RAG) checks, leaderboard evaluations, or lightweight QA pipelines where you need reasoning alongside the verdict.
+
+## Prompt
+
+```text
+We have been working on the following query:
+
+{query}
+
+We provided the following context:
+
+{context}
+
+And we have received the following response:
+
+{response}
+
+To ensure the response provided is relevant to the query, please answer the following question, including your reasoning:
+
+- Is the response provided relevant to the query provided? This includes the execution of the query, the provision of all requested information, and its relevance to the query.
+```
+
+## Example
+
+```text
+We have been working on the following query:
+
+<QUERY>
+Summarize the three most important features mentioned in our 2025 premium plan launch notes.
+</QUERY>
+
+We provided the following context:
+
+<CONTEXT>
+Excerpt: The 2025 premium plan launch introduced (1) unlimited work item automations, (2) hourly workspace backups retained for 30 days, and (3) security posture reports with automated CVE lookups.
+</CONTEXT>
+
+And we have received the following response:
+
+<RESPONSE>
+The premium plan focuses on automation, faster CI builds, and bundled design templates that ship later this year.
+</RESPONSE>
+
+To ensure the response provided is relevant to the query, please answer the following question, including your reasoning:
+
+- Is the response provided relevant to the query provided? This includes the execution of the query, the provision of all requested information, and its relevance to the query.
+```
+
+## Tips
+
+- Pair this evaluator with automated scoring by checking for positive or negative signals (e.g., "Yes" vs. "No") in the reasoning output.
+- Capture both the verdict and explanation so you can audit disagreements and refine upstream prompts.
+- Feed the evaluator exactly what the answering agent saw to avoid penalizing answers for missing context.


### PR DESCRIPTION
This pull request introduces a new evaluation category for prompts focused on assessing the quality of AI-generated responses. The main addition is a "Response Quality" section, including a dedicated evaluator prompt for checking the relevancy of model outputs. These changes improve the documentation structure and provide a clear, reusable prompt for evaluating whether AI answers are relevant and context-grounded.

**Documentation structure improvements:**

* Added a new "Evaluation" section to the main `README.md`, listing the "Response Quality" category and its purpose.

**New evaluator prompt:**

* Created `prompts/evaluation/response-quality/README.md` to introduce the "Response Quality" evaluators and link to the new relevancy evaluator.
* Added `prompts/evaluation/response-quality/response-relevancy-evaluator.md`, which defines a reusable prompt for judging if AI answers are relevant to the user query and grounded in provided context, with example usage and tips for scoring.