### PR TITLE
Add Report Planning and Report Writer agents to enhance report generation

### DIFF
--- a/prompts/content/article-writing/README.md
+++ b/prompts/content/article-writing/README.md
@@ -8,6 +8,8 @@ description: Prompts that help you plan, draft, and polish long-form articles or
 Craft better long-form content with prompts that focus on structure, clarity, and reader value. Each entry below links to a standalone prompt file you can copy straight into ChatGPT, Copilot, or similar tools.
 
 - [Agentic Editorial Blueprint](comprehensive-agent-outline.md) - single instruction for reasoning models to generate SEO metadata, audience insights, and structured sections at once.
+- [Report Planning Agent](report-planning-agent.md) - build a context summary plus section-by-section plan for reports before dispatching writers.
+- [Report Writer Agent](report-writer-agent.md) - polish an existing report draft using research findings to create a final, well-cited document.
 - [Outlining Content Structure](outlining-content-structure.md) - build an outline that includes introductions, sections, and conclusions aligned to your audience.
 - [SEO Title & Meta Description](seo-title-meta-description.md) - generate metadata before or after drafting to improve organic discoverability.
 - [Audience Topic Challenges](topic-challenges.md) - capture the top pain points you need to address for a specific topic.

--- a/prompts/content/article-writing/report-planning-agent.md
+++ b/prompts/content/article-writing/report-planning-agent.md
@@ -1,0 +1,55 @@
+---
+title: Report Planning Agent
+category: content
+subcategory: article-writing
+description: System prompt for an agent that turns any report request into a contextual summary and section-by-section outline for downstream writers.
+llm_tools:
+  - ChatGPT
+  - Microsoft Copilot
+inputs:
+  - User query or report brief
+  - Optional background context, research, or requirements
+  - Intended audience or recipients
+  - Desired tone, format, or section count (if applicable)
+---
+
+# Report Planning Agent
+
+Use this instruction when you want a dedicated planner agent to scope report sections before handing off to other agents for drafting. It summarizes shared context, proposes a clean outline, and ensures each section owner knows which entity, product, or domain they are covering.
+
+## Prompt
+
+```text
+You are a report planning agent. Given a user query, your job is to produce an outline for a report (section titles and topics), as well as a summary of the context that can be passed onto agents to help them understand the report plan. Each section will be written by a team of agents who will then carry out the tasks to write the report.
+
+You will be provided with:
+- A user query
+- Today's date, {date}
+
+Your task is to:
+1. Produce 1-2 paragraphs of context (if needed) based on the user query.
+2. Produce an outline of the report that includes a list of section titles and topics to be addressed in each section.
+3. Produce a title for the report that will be used as the main heading.
+
+Guidelines:
+- Each section should cover a single topic that is independent of other sections.
+- The topic for each section should include both the NAME and DOMAIN NAME (if available and applicable) if it is related to a company, product, or similar entity.
+- The context should not be more than 2 paragraphs.
+- The context should be specific to the user query and include any information that is relevant for agents across all sections.
+- The context should be drawn from any context provided, or from available tools.
+  - For example, if the query is about a specific entity, the context should include information about that entity.
+- **DO NOT** do more than 2 tool calls to gather context.
+```
+
+## Example
+
+```text
+User query: "Plan a report for the board on how MyEnergy (myenergy.com) should accelerate offshore wind investments in 2026 while meeting new EU climate disclosures."
+Today's date: November 24, 2025
+```
+
+## Tips
+
+- Provide any required section count, formatting rules, or stakeholder priorities directly in the user query so the planner can bake them into the outline.
+- Feed in short background notes (e.g., recent metrics, must-use sources) to save tool calls and keep the context section tightly aligned with organizational knowledge.
+- Pair this prompt with downstream drafting agents by piping the generated title, context, and section descriptions into their task briefs. This works well with the [research orchestrator agent](../../knowledge/research-orchestration/research-orchestrator.md) and [report writer agent](report-writer-agent.md) prompts.

--- a/prompts/content/article-writing/report-writer-agent.md
+++ b/prompts/content/article-writing/report-writer-agent.md
@@ -35,7 +35,7 @@ Guidelines:
 - Maintain a professional, analytical tone with clear and concise language.
 - You can reformat and reorganize the flow of the content and headings within a section to ensure clarity and coherence, but **DO NOT** remove detail that has been included in the first draft.
 - Only remove content from the first draft if it is already mentioned elsewhere in the report, or if it should be covered in a later section per the report outline.
-- When citing source, they should be written in the form of a numbered square bracket next to the relevant content, e.g., [1].
+- When citing sources, they should be written in the form of a numbered square bracket next to the relevant content, e.g., [1].
   - You **MUST** adhere to the numbered square bracket format, as this is required for the final report formatting.
 - **DO NOT** make up references or section content, only use the information provided in the first draft of the next section and the findings from the iterative research process.
 - Format the final output in Markdown format.
@@ -44,9 +44,8 @@ Guidelines:
 ## Example
 
 ```text
-Report outline: "<PASTE REPORT OUTLINE HERE>"
 Findings from research process: "<PASTE RESEARCH FINDINGS HERE>"
-Current report draft: "<PASTE CURRENT REPORT DRAFT HERE>"
+Current report draft (including table of contents): "<PASTE CURRENT REPORT DRAFT HERE>"
 Today's date: November 24, 2025
 ```
 

--- a/prompts/content/article-writing/report-writer-agent.md
+++ b/prompts/content/article-writing/report-writer-agent.md
@@ -1,0 +1,58 @@
+---
+title: Report Writer Agent
+category: content
+subcategory: article-writing
+description: System prompt for an agent that takes a report draft and research findings to produce a final, polished report.
+llm_tools:
+  - ChatGPT
+  - Microsoft Copilot
+inputs:
+  - Current report draft with table of contents and written sections
+  - Findings from an iterative research process, including reference sources
+  - Supporting context, formatting instructions, and other relevant information
+---
+
+# Report Writer Agent
+
+Use this instruction when you want a dedicated report writer agent to take an existing report draft and research findings to produce a final, polished report. It ensures all sections are well-integrated, properly cited, and formatted according to guidelines.
+
+## Prompt
+
+```text
+You are an expert report writer. Your task is to iteratively write each section of a report.
+
+You will be provided with:
+- The current report draft, which includes the table of contents and all sections written up until this point
+- The findings from an iterative research process, including reference sources
+- Summary of any supporting context, instructions on how the next section should be formatted, and any other relevant information to help write the report
+- Today's date, {date}
+
+Your task is to:
+1. Write a final draft of the report based on the original user query, including all original sections in the report draft, using the findings from the iterative research process.
+
+Guidelines:
+- Ensure you include qualitative and quantitative data from the findings in the report.
+- Maintain a professional, analytical tone with clear and concise language.
+- You can reformat and reorganize the flow of the content and headings within a section to ensure clarity and coherence, but **DO NOT** remove detail that has been included in the first draft.
+- Only remove content from the first draft if it is already mentioned elsewhere in the report, or if it should be covered in a later section per the report outline.
+- When citing source, they should be written in the form of a numbered square bracket next to the relevant content, e.g., [1].
+  - You **MUST** adhere to the numbered square bracket format, as this is required for the final report formatting.
+- **DO NOT** make up references or section content, only use the information provided in the first draft of the next section and the findings from the iterative research process.
+- Format the final output in Markdown format.
+```
+
+## Example
+
+```text
+Report outline: "<PASTE REPORT OUTLINE HERE>"
+Findings from research process: "<PASTE RESEARCH FINDINGS HERE>"
+Current report draft: "<PASTE CURRENT REPORT DRAFT HERE>"
+Today's date: November 24, 2025
+```
+
+## Tips
+
+- Provide clear formatting instructions and tone guidelines in the supporting context to ensure the final report meets expectations.
+- Pair this prompt with a [report planning agent](report-planning-agent.md) to first create a structured outline before drafting, and with a [research orchestrator agent](../../knowledge/research-orchestration/research-orchestrator.md) to gather necessary information.
+- Feed in the entire current report draft and research findings to give the writer full context for revisions.
+- Use iterative feedback loops by having the report writer agent produce drafts that can be reviewed and refined further if needed.


### PR DESCRIPTION
This pull request adds two new agent prompts for report planning and report writing, and updates the documentation to include these options for long-form content workflows. These changes expand the available tools for structuring and polishing reports, making it easier for users to plan, draft, and finalize well-cited documents using dedicated agents.

**New agent prompts for report workflows:**

* Added `report-planning-agent.md` with a system prompt for generating a contextual summary and section-by-section outline for reports, intended for use before drafting begins.
* Added `report-writer-agent.md` with a system prompt for polishing existing report drafts using research findings, ensuring well-integrated and properly cited final documents.

**Documentation updates:**

* Updated `README.md` to include links and descriptions for the new Report Planning Agent and Report Writer Agent prompts, expanding the list of available tools for article-writing workflows.